### PR TITLE
Strip whitespace from release version file contents.

### DIFF
--- a/Nito.BrowserBoss/Nito.BrowserBoss/WebDrivers/ChromeWebDriverSetup.cs
+++ b/Nito.BrowserBoss/Nito.BrowserBoss/WebDrivers/ChromeWebDriverSetup.cs
@@ -32,12 +32,15 @@ namespace Nito.BrowserBoss.WebDrivers
         }
 
         /// <summary>
-        /// Returns the newest version available for download. Currently always returns "2.45".
+        /// Returns the newest version available for download.
         /// </summary>
         protected override string AvailableVersion()
         {
             using (var client = new WebClient())
-                return client.DownloadString("http://chromedriver.storage.googleapis.com/LATEST_RELEASE");
+            {
+                var versionString = client.DownloadString("http://chromedriver.storage.googleapis.com/LATEST_RELEASE");
+                return System.Text.RegularExpressions.Regex.Replace(versionString, @"\s", "");
+            }
         }
 
         /// <summary>

--- a/Nito.BrowserBoss/Nito.BrowserBoss/WebDrivers/WebDriverSetupBase.cs
+++ b/Nito.BrowserBoss/Nito.BrowserBoss/WebDrivers/WebDriverSetupBase.cs
@@ -81,7 +81,7 @@ namespace Nito.BrowserBoss.WebDrivers
         /// </summary>
         private string LocalVersion()
         {
-            return !_localVersionFile.Exists ? null : File.ReadAllText(_localVersionFile.FullName);
+            return !_localVersionFile.Exists ? null : System.Text.RegularExpressions.Regex.Replace(File.ReadAllText(_localVersionFile.FullName), @"\s", "");
         }
 
         /// <summary>


### PR DESCRIPTION
http://chromedriver.storage.googleapis.com/LATEST_RELEASE file contains a newline which was causing the version check to fail.
