### PR TITLE
Support for executing asynchronous JavaScript

### DIFF
--- a/Nito.BrowserBoss/Nito.BrowserBoss/Boss.cs
+++ b/Nito.BrowserBoss/Nito.BrowserBoss/Boss.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Nito.BrowserBoss.Finders;
 using Nito.BrowserBoss.Loggers;
@@ -75,6 +75,23 @@ namespace Nito.BrowserBoss
         public static dynamic Script(string script, params object[] args)
         {
             return Browser.Script(script, args);
+        }
+
+        /// <summary>
+        /// Executes asynchronous JavaScript in this browser.
+        /// </summary>
+        /// <param name="script">The JavaScript to execute.</param>
+        /// <param name="args">The arguments to pass to <paramref name="script"/>.</param>
+        /// <remarks>
+        /// The script is executed asynchronous in the browser but this method
+        /// remains synchronous. The JavaScript supplied in <paramref name="script"/>
+        /// receives an extra argument that is a callback function that must be
+        /// invoked to signal the end of script execution. The function accepts
+        /// an argument that then becomes the return value of this method.
+        /// </remarks>
+        public static dynamic AsyncScript(string script, params object[] args)
+        {
+            return Browser.AsyncScript(script, args);
         }
 
         /// <summary>

--- a/Nito.BrowserBoss/Nito.BrowserBoss/Browser.cs
+++ b/Nito.BrowserBoss/Nito.BrowserBoss/Browser.cs
@@ -1,4 +1,5 @@
-﻿using Nito.BrowserBoss.WebDrivers;
+using System;
+using Nito.BrowserBoss.WebDrivers;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Firefox;
@@ -78,6 +79,32 @@ namespace Nito.BrowserBoss
         public dynamic Script(string script, params object[] args)
         {
             return ((IJavaScriptExecutor)WebDriver).ExecuteScript(script, args);
+        }
+
+        /// <summary>
+        /// Set the amount of time to wait for asynchronous JavaScript to execute
+        /// via the <see cref="AsyncScript"/>.
+        /// </summary>
+        public TimeSpan ScriptTimeout
+        {
+            set { WebDriver.Manage().Timeouts().SetScriptTimeout(value); }
+        }
+
+        /// <summary>
+        /// Executes asynchronous JavaScript in this browser.
+        /// </summary>
+        /// <param name="script">The JavaScript to execute.</param>
+        /// <param name="args">The arguments to pass to <paramref name="script"/>.</param>
+        /// <remarks>
+        /// The script is executed asynchronous in the browser but this method
+        /// remains synchronous. The JavaScript supplied in <paramref name="script"/>
+        /// receives an extra argument that is a callback function that must be
+        /// invoked to signal the end of script execution. The function accepts
+        /// an argument that then becomes the return value of this method.
+        /// </remarks>
+        public dynamic AsyncScript(string script, params object[] args)
+        {
+            return ((IJavaScriptExecutor)WebDriver).ExecuteAsyncScript(script, args);
         }
     }
 }


### PR DESCRIPTION
This is the PR for #10.

It adds `AsyncScript` to `Browser` and `Boss`. I called the method `AsyncScript` and not `ScriptAsync` to highlight that the script has to be asynchronous instead of the execution of the method itself being asynchronous. One would also expect that a method called `ScriptAsync` would return `Task<dynamic>` and that's not the case here. What's more, `AsyncScript` lines up nicely with `ExecuteAsyncScript` from `IJavaScriptExecutor`. The one downside of this, however, is that `ScriptAsync` doesn't sit there next to `Script` in the IntelliSense pop-up.

I also added `Browser.ScriptTimeout` as a _set-only_ property since there is no way to read out the value from the driver today (unless I missed something). We could make it readable nonetheless by caching the last value set through the property so that it can be returned later in the getter method. We would also have to assume a default of 0, which is what it is today but it could mislead if it changes in the future. To avoid assuming anything, an option would be for `ScriptTimeout` be a `TimeSpan?` that starts out as `null`, meaning no value was set via the property. Finally, if a set-only property seems odd then we could just turn it into a method. Both would be the most accurate representation of the what's really there today.

Since script timeout is 0 by default in the driver, the experience isn't very nice because the first attempt to use `AsyncScript` fails. You have to set the timeout first via `Browser.ScriptTimeout`. That seems against the spirit of the project, which is to make the interface super simple. So my question is, should `AsyncScript` set the timeout to some reasonable default of 30 seconds if the timeout has never been set before?

Let me know your thoughts on the above points.